### PR TITLE
Add task to install Helm secrets plugin

### DIFF
--- a/taskfiles/install/Taskfile.yaml
+++ b/taskfiles/install/Taskfile.yaml
@@ -4,17 +4,47 @@
 
 version: '3'
 
+vars:
+  HELM_PLUGIN_SECRETS_VERSION: 4.6.5
+
 tasks:
   tools:
     run: once
-    desc: Use asdf to install the tools defined in .tool-versions.
+    desc: Use asdf to install the tools defined in .tool-versions and Helm plugins.
     cmds:
       - awk '{print $1}' .tool-versions | xargs -P 8 -I _ asdf plugin add _
       - awk '{print $1, $2}' .tool-versions | xargs -P 8 -n 2 asdf install $1 $2
       - awk '{print $1, $2}' .tool-versions | xargs -n 2 asdf set $1 $2
+      - task: helm-plugins
     preconditions:
       - sh: command -v asdf > /dev/null
         msg: "asdf is not installed. Please install asdf and try again."
+
+  helm-plugins:
+    run: once
+    desc: Install Helm plugins
+    cmds:
+      - |
+        # Install Helm secrets plugin {{.HELM_PLUGIN_SECRETS_VERSION}}
+        # Uninstall if secrets plugin exists but is not version {{.HELM_PLUGIN_SECRETS_VERSION}}
+        if helm plugin list | grep -q "^secrets" && ! helm plugin list | grep -q "^secrets.*{{.HELM_PLUGIN_SECRETS_VERSION}}"; then
+          helm plugin uninstall secrets
+          rm -rf ~/Library/Caches/helm/plugins/https-github.com-jkroepke-helm-secrets ~/Library/helm/plugins/helm-secrets || true
+        fi
+
+        # Install {{.HELM_PLUGIN_SECRETS_VERSION}} if not already installed
+        if ! helm plugin list | grep -q "^secrets.*{{.HELM_PLUGIN_SECRETS_VERSION}}"; then
+          # Clean potential corrupted cache files
+          rm -rf ~/Library/Caches/helm/plugins/https-github.com-jkroepke-helm-secrets ~/Library/helm/plugins/helm-secrets || true
+          git config --global core.fsmonitor false
+
+          helm plugin install https://github.com/jkroepke/helm-secrets --version v{{.HELM_PLUGIN_SECRETS_VERSION}}
+
+          git config --global core.fsmonitor true
+        fi
+    preconditions:
+      - sh: command -v helm > /dev/null
+        msg: "helm is not installed. Please run task install:tools first."
 
   pre-commit:
     desc: Install pre-commit hooks.

--- a/taskfiles/install/Taskfile.yaml
+++ b/taskfiles/install/Taskfile.yaml
@@ -25,9 +25,9 @@ tasks:
     desc: Install Helm plugins
     cmds:
       - |
-        # Install Helm secrets plugin {{.HELM_PLUGIN_SECRETS_VERSION}}
-        # Uninstall if secrets plugin exists but is not version {{.HELM_PLUGIN_SECRETS_VERSION}}
-        if helm plugin list | grep -q "^secrets" && ! helm plugin list | grep -q "^secrets.*{{.HELM_PLUGIN_SECRETS_VERSION}}"; then
+        # Install Helm secrets plugin {{ .HELM_PLUGIN_SECRETS_VERSION }}
+        # Uninstall if secrets plugin exists but is not version {{ .HELM_PLUGIN_SECRETS_VERSION }}
+        if helm plugin list | grep -q "^secrets" && ! helm plugin list | grep -q "^secrets.*{{ .HELM_PLUGIN_SECRETS_VERSION }}"; then
           helm plugin uninstall secrets
           rm -rf ~/Library/Caches/helm/plugins/https-github.com-jkroepke-helm-secrets ~/Library/helm/plugins/helm-secrets || true
         fi

--- a/taskfiles/install/Taskfile.yaml
+++ b/taskfiles/install/Taskfile.yaml
@@ -32,13 +32,13 @@ tasks:
           rm -rf ~/Library/Caches/helm/plugins/https-github.com-jkroepke-helm-secrets ~/Library/helm/plugins/helm-secrets || true
         fi
 
-        # Install {{.HELM_PLUGIN_SECRETS_VERSION}} if not already installed
-        if ! helm plugin list | grep -q "^secrets.*{{.HELM_PLUGIN_SECRETS_VERSION}}"; then
+        # Install {{ .HELM_PLUGIN_SECRETS_VERSION }} if not already installed
+        if ! helm plugin list | grep -q "^secrets.*{{ .HELM_PLUGIN_SECRETS_VERSION }}"; then
           # Clean potential corrupted cache files
           rm -rf ~/Library/Caches/helm/plugins/https-github.com-jkroepke-helm-secrets ~/Library/helm/plugins/helm-secrets || true
           git config --global core.fsmonitor false
 
-          helm plugin install https://github.com/jkroepke/helm-secrets --version v{{.HELM_PLUGIN_SECRETS_VERSION}}
+          helm plugin install https://github.com/jkroepke/helm-secrets --version v{{ .HELM_PLUGIN_SECRETS_VERSION }}
 
           git config --global core.fsmonitor true
         fi


### PR DESCRIPTION
## What 

See title. 

## Why 

```
task run
task: [run] dctl up --config example/datafeeds/env.toml --namespace crib-local --remote
3:30PM INF Creating development environment Config=example/datafeeds/env.toml Remote=true
3:30PM INF Loading configuration input Path=example/datafeeds/env.toml
3:30PM INF Creating plan component=datafeeds
Error: failed to apply plan: failed to create helm chart: Cannot read properties of undefined (reading 'split')
Usage:
  dctl up [flags]

Aliases:
  up, u

Flags:
  -h, --help   help for up

Global Flags:
  -u, --blockscout_url string   EVM RPC node URL (default "http://host.docker.internal:8545/")
  -c, --config string           Configuration file for the environment (default "env.toml,overrides.toml")
  -n, --namespace string        Remote environment namespace (default "remote-devenv")
  -r, --remote                  Execution mode: by default we run local docker, with '-r' we run remotely in K8s

3:30PM ERR error="failed to apply plan: failed to create helm chart: Cannot read properties of undefined (reading 'split')" component=datafeeds
task: Failed to run task "run": exit status 1
```

See: https://github.com/helm/helm/issues/30876
