### PR TITLE
fix: Don’t provide commit_msg to GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/commit-message-enforcement.yaml
+++ b/.github/workflows/commit-message-enforcement.yaml
@@ -62,12 +62,10 @@ jobs:
           if [[ "$COMMIT_MSG" =~ $CONVENTIONAL_PATTERN ]]; then
             {
               echo "is_valid=true"
-              echo "commit_msg=$COMMIT_MSG"
             } >> "$GITHUB_OUTPUT"
           else
             {
               echo "is_valid=false"
-              echo "commit_msg=$COMMIT_MSG"
             } >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
This value isn’t used and can’t be correctly saved because of multiline strings.

Fixes COP-1580