### PR TITLE
feat: use GitHub’s API to generate release notes

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -3,6 +3,7 @@
   "packages": {
     ".": {
       "package-name": "crib-sdk",
+      "changelog-type": "github",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": false,
       "changelog-sections": [


### PR DESCRIPTION
I believe the GitHub API will add more context and highlight individual contributions.